### PR TITLE
ui_modal: show input/control hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@
     - higher level (e.g. safe) way of queuing the config modal opening in general.
   - `ui_modal`
     - `MenuAction` events
-      - ability to show controls hints
-        - Tricky part: `MenuAction::Apply` handled elsewhere. maybe need special way of adding ctrl hints to root doc?
+      - Causes crash when setting text? Uncertain about cause - seems intermittent between builds and only when first opening the config modal and `element_ptr->base->SetInnerRML(text)` called when recompui updates elements in `to_set_text`
+      - `MenuAction::Apply` handled elsewhere. maybe need special way of adding ctrl hints to root doc?
   - `ui_state`
     - controller button repeats (should be in recompinput in the future)
       - Change to be directional inputs only

--- a/recompinput/include/recompinput/input_types.h
+++ b/recompinput/include/recompinput/input_types.h
@@ -86,6 +86,10 @@ namespace recompinput {
         static InputField controller_analog(SDL_GameControllerAxis axis, bool positive = true) {
             return InputField{ InputType::ControllerAnalog, positive ? (static_cast<int32_t>(axis) + 1) : -(static_cast<int32_t>(axis) + 1) };
         }
+
+        bool is_empty() const {
+            return input_type == InputType::None;
+        }
     };
 
     inline void to_json(nlohmann::json& j, const InputField& field) {

--- a/recompui/include/recompui/recompui.h
+++ b/recompui/include/recompui/recompui.h
@@ -147,5 +147,12 @@ namespace recompui {
         };
 
         MenuAction menu_action_from_rml_key(const Rml::Input::KeyIdentifier& key);
+        // Returns a GameInput for a given MenuAction.
+        // GameInput::COUNT returned if no mapping exists.
+        recompinput::GameInput game_input_from_menu_action(const MenuAction& action);
+
+        // The ultra high F keys are used to give RmlUi unique keys for menu actions that can be invoked from controllers.
+        // This allows you to check if InputField.input_id is one of those (e.g. hiding hints). 
+        bool is_sdl_input_fake_mapped(int32_t sdl_key);
     };
 }

--- a/recompui/src/base/ui_state.cpp
+++ b/recompui/src/base/ui_state.cpp
@@ -536,6 +536,21 @@ recompui::MenuAction recompui::menu_action_mapping::menu_action_from_rml_key(con
     return recompui::MenuAction::None;
 }
 
+recompinput::GameInput recompui::menu_action_mapping::game_input_from_menu_action(const MenuAction& action) {
+    for (auto &action_pair : recompui::menu_action_mapping::rml_key_to_action) {
+        if (action_pair.second.action == action) {
+            return action_pair.second.input;
+        }
+    }
+    return recompinput::GameInput::COUNT;
+}
+
+bool recompui::menu_action_mapping::is_sdl_input_fake_mapped(int32_t sdl_key) {
+    return sdl_key == static_cast<int32_t>(SDL_SCANCODE_F15) ||
+            sdl_key == static_cast<int32_t>(SDL_SCANCODE_F16) ||
+            sdl_key == static_cast<int32_t>(SDL_SCANCODE_F17);
+}
+
 // Extends RmlSDL::ConvertKey for some extra mapping slots
 Rml::Input::KeyIdentifier convert_sdl_to_rml(int sdl_key) {
     Rml::Input::KeyIdentifier identifier = RmlSDL::ConvertKey(sdl_key);

--- a/recompui/src/elements/ui_modal.h
+++ b/recompui/src/elements/ui_modal.h
@@ -6,6 +6,8 @@
 #include "elements/ui_config_page.h"
 #include "elements/ui_tab_set.h"
 
+#include "recompinput/recompinput.h"
+
 namespace recompui {
 
     class Modal;
@@ -51,16 +53,26 @@ namespace recompui {
 
     class TabbedModal;
 
+    struct MenuActionCallback {
+        std::function<void()> callback;
+        std::string description;
+    };
+
     class Modal : public Element {
         friend class TabbedModal;
     protected:
         bool is_open = false;
         Element *modal_element = nullptr;
         ConfigHeaderFooter *header = nullptr;
+        Element *modal_overlay = nullptr;
         Element *body = nullptr;
+        Element *menu_actions_wrapper = nullptr;
         ModalType modal_type;
         std::function<void()> on_close_callback;
-        std::unordered_map<MenuAction, std::function<void()>> menu_action_callbacks;
+        std::unordered_map<MenuAction, MenuActionCallback> menu_action_callbacks;
+
+        recompinput::InputDevice last_input_device = recompinput::InputDevice::COUNT;
+        int last_input_profile = -1;
 
         virtual void process_event(const Event &e) override;
         std::string_view get_type_name() override { return "Modal"; }
@@ -78,7 +90,10 @@ namespace recompui {
         Element *get_body() { return body; }
 
         void set_on_close_callback(std::function<void()> callback);
-        void set_menu_action_callback(MenuAction action, std::function<void()> callback);
+        // Adds a callback for MenuAction events. Description is shown under the modal if provided.
+        void set_menu_action_callback(MenuAction action, std::function<void()> callback, std::string description = "");
+        void remove_menu_action_callback(MenuAction action);
+        void render_menu_actions();
     };
 
     class TabbedModal : public Modal {


### PR DESCRIPTION
Shows keyboard/controller hints based on the current input mapping below the modal. 
Currently a draft due to cmake refactor and unknown crash caused by setting SetInnerRml.

My current replication isn't guaranteed to happen 100% of the time but here is how I replicate it:
- Build as x64-Debug using the "play" button in VS at the top
- Click on "Settings" on the main menu
- If it doesn't throw this error, stop debugging and retry

<img width="414" height="214" alt="image" src="https://github.com/user-attachments/assets/eb2c0e29-0932-49a7-bf72-4ed09511939c" />


<img width="819" height="221" alt="image" src="https://github.com/user-attachments/assets/effdafe5-1c31-4d73-ad99-395281c9dfa9" />

The crash occurs here above ^ in rmlui. children is a size of zero and `num_non_dom_children` is zero. Could be an rmlui bug maybe? Given that children.end() - `num_non_dom_children` is showing NULL, i feel like it has to be due to rmlui in some way.

<img width="838" height="79" alt="image" src="https://github.com/user-attachments/assets/561fd98e-8650-489c-8c45-36415546bf93" />
