### PR TITLE
Restore cont/kb toggle + simplified Toggle color theming + added IconToggle component

### DIFF
--- a/recompui/src/config/ui_config_page_controls.cpp
+++ b/recompui/src/config/ui_config_page_controls.cpp
@@ -468,14 +468,12 @@ void ConfigPageControls::render_footer() {
         auto footer_left = footer->get_left();
         footer_left->clear_children();
         if (!multiplayer_enabled) {
-            keyboard_toggle = context.create_element<Toggle>(footer_left);
+            keyboard_toggle = context.create_element<IconToggle>(footer_left, "icons/Cont.svg", "icons/Keyboard.svg", ToggleSize::Large);
             keyboard_toggle->set_checked(single_player_show_keyboard_mappings);
             keyboard_toggle->add_checked_callback([this](bool checked) {
                 this->single_player_show_keyboard_mappings = checked;
                 this->update_control_mappings();
             });
-            Label *kb_label = context.create_element<Label>(footer_left, "Enable keyboard", LabelStyle::Normal);
-            kb_label->set_margin_left(12.0f);
         }
     }
     {

--- a/recompui/src/config/ui_config_page_controls.h
+++ b/recompui/src/config/ui_config_page_controls.h
@@ -148,7 +148,7 @@ protected:
     std::vector<PlayerCard*> player_cards;
     std::vector<GameInputRowsWrapper*> rows_wrappers;
     std::vector<GameInputRow*> game_input_rows;
-    Toggle *keyboard_toggle;
+    IconToggle *keyboard_toggle;
     Element *description_container = nullptr;
     on_player_bind_callback on_player_bind;
     Element *nav_up_element = nullptr;

--- a/recompui/src/elements/ui_toggle.h
+++ b/recompui/src/elements/ui_toggle.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ui_element.h"
+#include "ui_svg.h"
 
 namespace recompui {
 
@@ -8,6 +9,20 @@ namespace recompui {
         Medium,
         Large,
         Default = Large
+    };
+
+    struct ToggleColorTheme {
+        theme::color border;
+        theme::color bg_hover;
+        theme::color floater;
+        theme::color floater_disabled;
+    };
+
+    struct ToggleStyleGroup {
+        Style normal; // not used for unchecked state
+        Style hover;
+        Style focus;
+        Style disabled;
     };
 
     class Toggle : public Element {
@@ -18,31 +33,25 @@ namespace recompui {
         float floater_left = 0.0f;
         std::chrono::high_resolution_clock::duration last_time;
         std::list<std::function<void(bool)>> checked_callbacks;
-        Style checked_style;
-        Style hover_style;
-        Style focus_style;
-        Style checked_hover_style;
-        Style checked_focus_style;
-        Style disabled_style;
-        Style checked_disabled_style;
 
         struct {
-            Style checked;
-            Style hover;
-            Style focus;
-            Style checked_hover;
-            Style checked_focus;
-            Style disabled;
-            Style checked_disabled;
-        } inner_border_styles;
+            ToggleStyleGroup unchecked;
+            ToggleStyleGroup unchecked_floater;
+            ToggleStyleGroup unchecked_inner_border;
+            ToggleStyleGroup checked;
+            ToggleStyleGroup checked_floater;
+            ToggleStyleGroup checked_inner_border;
+        } style_groups;
 
-        Style floater_checked_style;
-        Style floater_disabled_style;
-        Style floater_disabled_checked_style;
         bool checked = false;
         ToggleSize size = ToggleSize::Default;
 
-        void set_checked_internal(bool checked, bool animate, bool setup, bool trigger_callbacks);
+        virtual const ToggleColorTheme &get_toggle_color_theme_unchecked();
+        virtual const ToggleColorTheme &get_toggle_color_theme_checked();
+
+        void set_toggle_colors(bool for_checked);
+
+        virtual void set_checked_internal(bool checked, bool animate, bool setup, bool trigger_callbacks);
         void set_all_style_enabled(std::string_view style_name, bool enabled);
         float floater_left_target() const;
 
@@ -54,6 +63,25 @@ namespace recompui {
         void set_checked(bool checked);
         bool is_checked() const;
         void add_checked_callback(std::function<void(bool)> callback);
+    };
+
+    class IconToggle : public Toggle {
+    protected:
+        Svg *icon_svg_left;
+        Svg *icon_svg_right;
+
+        Style icon_disabled_style;
+
+        // This being an override doesn't apply because it is called during Toggle's constructor.
+        // So set_toggle_colors(false) gets called in IconToggle's constructor in order for this to be applied properly.
+        const ToggleColorTheme &get_toggle_color_theme_unchecked() override;
+
+        void set_checked_internal(bool checked, bool animate, bool setup, bool trigger_callbacks) override;
+
+        // Element overrides.
+        std::string_view get_type_name() override { return "IconToggle"; }
+    public:
+        IconToggle(Element *parent, std::string_view icon_src_left, std::string_view icon_src_right, ToggleSize size = ToggleSize::Default);
     };
 
 } // namespace recompui


### PR DESCRIPTION
- Added IconToggle component
- Changed the way the styling is organized so it is easier to create on/off overrides
- Switches "keyboard enabled" to use IconToggle with controller/keyboard icons



https://github.com/user-attachments/assets/e836e6c0-2728-446d-ad16-7a6360492c0a

