### PR TITLE
reduce comically large slider size at wide resolutions

### DIFF
--- a/recompui/src/config/ui_config_option.cpp
+++ b/recompui/src/config/ui_config_option.cpp
@@ -197,7 +197,7 @@ ConfigOptionNumber::ConfigOptionNumber(
 
     slider = context.create_element<Slider>(this, num_opt.percent ? SliderType::Percent : SliderType::Double);
     slider->set_width(100.0f, Unit::Percent);
-    slider->set_max_width(100.0f, Unit::Percent);
+    slider->set_max_width(512.0f, Unit::Dp);
 
     slider->set_min_value(num_opt.min);
     slider->set_max_value(num_opt.max);


### PR DESCRIPTION
Showing here that behavior works from 4:3ish to as wide as you want. Slider width just caps at 512dp

<img width="1179" height="993" alt="image" src="https://github.com/user-attachments/assets/37b99c19-ce2d-4531-85cd-68c93b1176ae" />
<img width="2525" height="999" alt="image" src="https://github.com/user-attachments/assets/867840bf-f647-4530-afcc-d7a64384834a" />
