### PR TITLE
Single player regression fixes

### DIFF
--- a/recompinput/include/recompinput/input_events.h
+++ b/recompinput/include/recompinput/input_events.h
@@ -4,4 +4,5 @@
 
 namespace recompinput {
     void handle_events();
+    void purge_deferred_controller_profiles();
 }

--- a/recompinput/include/recompinput/profiles.h
+++ b/recompinput/include/recompinput/profiles.h
@@ -59,7 +59,7 @@ namespace recompinput {
         void initialize_input_bindings();
         int get_sp_controller_profile_index();
         int get_sp_keyboard_profile_index();
-        int get_mp_keyboard_profile_index(int player_index);
+        int get_or_create_mp_keyboard_profile_index(int player_index);
         std::string get_string_from_controller_guid(ControllerGUID guid);
         bool get_n64_input(int player_index, uint16_t* buttons_out, float* x_out, float* y_out);
 

--- a/recompinput/src/players.cpp
+++ b/recompinput/src/players.cpp
@@ -1,6 +1,7 @@
 #include "recompinput/recompinput.h"
 #include "recompinput/players.h"
 #include "recompinput/profiles.h"
+#include "recompinput/input_events.h"
 #include "ultramodern/ultramodern.hpp"
 #include "composites/ui_assign_players_modal.h"
 #include "config/ui_config_page_controls.h"
@@ -77,6 +78,10 @@ bool players::is_single_player_mode() {
 }
 
 void players::set_single_player_mode(bool single_player) {
+    if (!single_player && single_player != PlayerState.single_player_mode) {
+        purge_deferred_controller_profiles();
+    }
+
     PlayerState.single_player_mode = single_player;
 }
 
@@ -156,7 +161,7 @@ void playerassignment::commit_player_assignment() {
                 profiles::set_input_profile_for_player(i, cont_profile_index, InputDevice::Controller);
             }
         } else {
-            profiles::set_input_profile_for_player(i, profiles::get_mp_keyboard_profile_index(i), InputDevice::Keyboard);
+            profiles::set_input_profile_for_player(i, profiles::get_or_create_mp_keyboard_profile_index(i), InputDevice::Keyboard);
         }
     }
 }

--- a/recompinput/src/profiles.cpp
+++ b/recompinput/src/profiles.cpp
@@ -130,7 +130,7 @@ namespace recompinput {
         }
 
         int index = (int)(input_profiles.size());
-        InputProfile profile;
+        InputProfile profile{};
         profile.key = key;
         profile.name = name;
         profile.device = device;

--- a/recompui/src/composites/ui_player_card.cpp
+++ b/recompui/src/composites/ui_player_card.cpp
@@ -79,7 +79,7 @@ PlayerCard::PlayerCard(
 
         int device_profile_index = has_controller
             ? recompinput::profiles::get_controller_profile_index_from_sdl_controller(player.controller)
-            : recompinput::profiles::get_mp_keyboard_profile_index(player_index);
+            : recompinput::profiles::get_or_create_mp_keyboard_profile_index(player_index);
 
         if (device_profile_index >= 0) {
             options.emplace_back(


### PR DESCRIPTION
> 1) no multiplayer keyboard profiles should be being created at all until a game goes into multiplayer mode (can just save none for now and do this post banjo)
> 2) the number of multiplayer keyboard profiles created should be based on how many people are actually using keyboard in multiplayer (can be postponed until post banjo)
> 3) controller-specific profiles shouldn't be created in singleplayer mode
> 4) the default control scheme needs to apply to the singleplayer profiles 

1: handled, only created when a mp player is assigned to kb
2: handled by the former
3: handled, connected controllers defer creating controller mappings until single player is enabled
4: handled